### PR TITLE
Remove logging when deleting a test

### DIFF
--- a/src/client/tester.js
+++ b/src/client/tester.js
@@ -19,7 +19,6 @@ export default class Tester extends Component {
         let changed = tests.slice(0)
         changed.splice(i, 1)
         this.props.setTests(changed)
-        console.log(shouldFocus)
         if(shouldFocus === true) setImmediate(e => {
             this.refs['test'+Math.min(i,changed.length - 1)].focus()
         })


### PR DESCRIPTION
It gets in the way of actual parse errors in the console.